### PR TITLE
feat(auth|switch): Command flags for switching git config

### DIFF
--- a/api/queries_user.go
+++ b/api/queries_user.go
@@ -14,6 +14,17 @@ func CurrentLoginName(client *Client, hostname string) (string, error) {
 	return query.Viewer.Login, err
 }
 
+func CurrentLoginNameAndEmail(client *Client, hostname string) (string, string, error) {
+	var query struct {
+		Viewer struct {
+			Login string
+			Email string
+		}
+	}
+	err := client.Query(hostname, "UserCurrent", &query, nil)
+	return query.Viewer.Login, query.Viewer.Email, err
+}
+
 func CurrentLoginNameAndOrgs(client *Client, hostname string) (string, []string, error) {
 	var query struct {
 		Viewer struct {

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -38,7 +38,8 @@ func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 		httpClient.Transport = verboseLog(IO.ErrOut, logTraffic, IO.ColorEnabled())(httpClient.Transport)
 	}
 
-	minimumScopes := []string{"repo", "read:org", "gist"}
+	// extra scopes needed for the new gh auth switch (-g or -l) features
+	minimumScopes := []string{"repo", "read:org", "gist", "read:user", "user:email"}
 	scopes := append(minimumScopes, additionalScopes...)
 
 	callbackURI := "http://127.0.0.1/callback"

--- a/pkg/cmd/auth/shared/git_credential.go
+++ b/pkg/cmd/auth/shared/git_credential.go
@@ -60,6 +60,54 @@ func (flow *GitCredentialFlow) Setup(hostname, username, authToken string) error
 	return flow.gitCredentialSetup(hostname, username, authToken)
 }
 
+func (flow *GitCredentialFlow) SwitchLocalGitUsernameAndEmail(email, username string) error {
+	ctx := context.Background()
+
+	preConfiguredCmd, err := flow.GitClient.Command(ctx, "config", "--local", "user.name", username)
+	if err != nil {
+		return err
+	}
+	_, err = preConfiguredCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	preConfiguredCmd, err = flow.GitClient.Command(ctx, "config", "--local", "user.email", email)
+	if err != nil {
+		return err
+	}
+	_, err = preConfiguredCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (flow *GitCredentialFlow) SwitchGlobalGitUsernameAndEmail(email, username string) error {
+	ctx := context.Background()
+
+	preConfiguredCmd, err := flow.GitClient.Command(ctx, "config", "--global", "user.name", username)
+	if err != nil {
+		return err
+	}
+	_, err = preConfiguredCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	preConfiguredCmd, err = flow.GitClient.Command(ctx, "config", "--global", "user.email", email)
+	if err != nil {
+		return err
+	}
+	_, err = preConfiguredCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (flow *GitCredentialFlow) gitCredentialSetup(hostname, username, password string) error {
 	gitClient := flow.GitClient
 	ctx := context.Background()


### PR DESCRIPTION
Flags for allowing `gh auth switch` to modify git config. 
- `gh auth switch -g` or `gh auth switch --global` for changing user's `git config --global` `user.name` and `user.email`
- `gh auth switch -l` or `gh auth switch --local` for changing user's `git config --local` `user.name` and `user.email`

The `cli` fetches the information from the user's account by using Github's GraphQL http client. If the user does not have a public email, the command will set a default `@noreply.gihub.com` address. 